### PR TITLE
feat: autogenerate requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,83 @@
-sphinx               >=3.0,<4.0
-sphinx-rtd-theme     >=0.5,<1.0
-sphinx-autoapi       >=1.5,<2.0
-sphinx-copybutton    >=0.3,<1.0
-tomlkit              >=0.7,<1.0
+alabaster==0.7.12; python_version >= "3.6"
+appdirs==1.4.4; python_version >= "3.6" and python_full_version >= "3.6.1"
+astroid==2.4.2; python_version >= "3.6"
+atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
+attrs==20.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+babel==2.9.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+bandit==1.7.0; python_version >= "3.5"
+black @ git+https://github.com/psf/black.git@692c0f50d91 ; python_version >= "3.6"
+certifi==2020.12.5; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
+cfgv==3.2.0; python_full_version >= "3.6.1"
+chardet==4.0.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
+click==7.1.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+colorama==0.4.4; python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") or python_full_version >= "3.5.0" and python_version >= "3.7" and platform_system == "Windows" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
+coverage==5.4; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "4")
+distlib==0.3.1; python_full_version >= "3.6.1"
+docutils==0.16; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+filelock==3.0.12; python_full_version >= "3.6.1"
+flake8-bugbear==20.11.1; python_version >= "3.6"
+flake8-docstrings==1.5.0
+flake8==3.8.4; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+gitdb==4.0.5; python_version >= "3.5"
+gitpython==3.1.12; python_version >= "3.5"
+grayskull==0.8.4; python_version >= "3.7"
+identify==1.5.13; python_full_version >= "3.6.1"
+idna==2.10; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
+imagesize==1.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+iniconfig==1.1.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+jinja2==2.11.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+lazy-object-proxy==1.4.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+markupsafe==1.1.1; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"
+mccabe==0.6.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+mypy-extensions==0.4.3; python_version >= "3.6"
+mypy==0.800; python_version >= "3.5"
+nodeenv==1.5.0; python_full_version >= "3.6.1"
+packaging==20.9; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+pathspec==0.8.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+pbr==5.5.1; python_version >= "3.6"
+pluggy==0.13.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+pre-commit-hooks==3.4.0; python_full_version >= "3.6.1"
+pre-commit==2.10.0; python_full_version >= "3.6.1"
+progressbar2==3.53.1; python_version >= "3.7"
+py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+pycodestyle==2.6.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+pydocstyle==5.1.1; python_version >= "3.5"
+pyflakes==2.2.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+pygments==2.7.4; python_version >= "3.6"
+pyparsing==2.4.7; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+pytest-cov==2.11.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+pytest==6.2.2; python_version >= "3.6"
+python-utils==2.5.5; python_version >= "3.7"
+pytz==2021.1; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.5"
+pyyaml==5.4.1; python_full_version >= "3.6.1" and python_version >= "3.5" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
+rapidfuzz==0.12.5; python_version >= "3.7"
+regex==2020.11.13; python_version >= "3.6"
+requests==2.25.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+ruamel.yaml.clib==0.2.2; platform_python_implementation == "CPython" and python_version < "3.9" and python_version >= "3.7"
+ruamel.yaml.jinja2==0.2.4; python_version >= "3.7"
+ruamel.yaml==0.16.12; python_version >= "3.7" and python_full_version >= "3.6.1"
+six==1.15.0; python_full_version >= "3.6.1" and python_version >= "3.7" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7")
+smmap==3.0.5; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.5"
+snowballstemmer==2.1.0; python_version >= "3.6"
+sphinx-autoapi==1.7.0; python_version >= "3.6"
+sphinx-copybutton==0.3.1
+sphinx-rtd-theme==0.5.1
+sphinx==3.4.3; python_version >= "3.5"
+sphinxcontrib-applehelp==1.0.2; python_version >= "3.6"
+sphinxcontrib-devhelp==1.0.2; python_version >= "3.6"
+sphinxcontrib-htmlhelp==1.0.3; python_version >= "3.6"
+sphinxcontrib-jsmath==1.0.1; python_version >= "3.6"
+sphinxcontrib-qthelp==1.0.3; python_version >= "3.6"
+sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.6"
+stdlib-list==0.8.0; python_version >= "3.7"
+stevedore==3.3.0; python_version >= "3.6"
+toml==0.10.2; python_full_version >= "3.6.1" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
+tomlkit==0.7.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+typed-ast==1.4.2; python_version >= "3.6"
+typer==0.3.2; python_version >= "3.6"
+typing-extensions==3.7.4.3; python_version >= "3.5"
+unidecode==1.1.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+urllib3==1.26.3; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4" and python_version >= "3.7"
+virtualenv==20.4.2; python_full_version >= "3.6.1"
+wrapt==1.12.1; python_version >= "3.6"
+tyrannosaurus

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist = py39
 [testenv]
 whitelist_externals =
     poetry
+    /bin/sh
 skipdist = True
 # the - prefix means ignore nonzero exit codes
 commands =
@@ -25,6 +26,8 @@ commands =
     - poetry run flake8 tyrannosaurus
     - poetry run flake8 docs
     - poetry run flake8 --ignore=D100,D101,D102,D103,D104,S101,W503,E203,E225,E301,E302,E501,D107,D200,D205,D400,D403,D409,D410,D411,D212,W391,W293 tests
+	poetry export --dev --without-hashes -f requirements.txt --output docs/requirements.txt
+    /bin/sh -c 'poetry version | cut -d " " -f1 >> {toxinidir}/docs/requirements.txt'
     poetry run sphinx-build -b html docs docs/html
 
 


### PR DESCRIPTION
I felt it redundant that we had to maintain a requirements.txt for sphinx separately from the pyproject.toml. This will build it automatically. The only weirdness is that it requires /bin/sh to add the project package itself so Windows machines will need another solution. I needed to add the package in a project where I was generating the version from importlib.metadata. I'm not 100% positive it's needed but this worked for me.